### PR TITLE
ビルトインcd作成、環境変数上書きに関する関数作成

### DIFF
--- a/submission/Makefile
+++ b/submission/Makefile
@@ -25,6 +25,7 @@ SRCS        = main.c \
 			  parser/expand_utils.c \
 			  env/env_init.c \
 			  env/env_utils.c \
+              env/env_update.c \
               builtins/builtin_utils.c \
               builtins/builtin_echo.c \
               builtins/builtin_pwd.c \

--- a/submission/includes/minishell.h
+++ b/submission/includes/minishell.h
@@ -128,6 +128,7 @@ t_env   *init_env(char **envp);
 void    free_env(t_env *env);
 char    *get_env_value(t_env *env, char *key);
 char    **env_to_envp(t_env *env);
+int update_env_value(t_env **env, char *key, char *new_value);
 
 // debug.c
 void debug_print_tokens(t_token *tokens); //! Debug提出前に削除

--- a/submission/includes/minishell.h
+++ b/submission/includes/minishell.h
@@ -171,7 +171,7 @@ int     ft_unset(t_cmd *cmd, t_shell *shell);
 // builtins/builtin_exit.c
 int     ft_exit(t_cmd *cmd, t_shell *shell);
 
-// executor.c (ビルトイン判定)
+// builtin_utils.c (ビルトイン判定)
 int     is_builtin(char *cmd);
 int     exec_builtin(t_cmd *cmd, t_shell *shell);
 

--- a/submission/srcs/builtins/builtin_cd.c
+++ b/submission/srcs/builtins/builtin_cd.c
@@ -1,1 +1,122 @@
-/*homura担当*/
+#include "minishell.h"
+#include "libft.h"
+#include <unistd.h>
+
+/*-----テスト-----
+minishell> env と打って、最初の PWD と OLDPWD を確認する。
+minishell> cd /tmp で移動する。
+minishell> env と打って、もう一度環境変数リストを見る。
+
+PWD=/tmp となり、OLDPWDが前までいたディレクトリのパスに書き換わっていれば、環境変数の更新ロジックは成功。
+*/
+/*
+** ==========================================
+** どこへ移動するか（引数のチェック）
+** ==========================================
+** 成功時は移動先のパス(文字列)を返し、失敗時はNULLを返すヘルパー関数
+*/
+static char *get_cd_path(t_cmd *cmd, t_shell *shell)
+{
+    char *path;
+
+    if (cmd->args[1] == NULL)
+    {
+        // 引数なし (単なる `cd`) の場合、HOMEディレクトリを探す
+        path = get_env_value(shell->env, "HOME");
+        // ?NULLになるときってどんなとき？
+        // case1: unset HOMEしたときpath == NULLになるのでエラー処理が必要。
+        // case2: $ env -i ./minishell (環境変数をすべて空っぽにして起動)
+        if (path == NULL)
+            ft_putendl_fd("minishell: cd: HOME not set", STDERR_FILENO);
+        return (path);
+    }
+    else if (cmd->args[2] != NULL)
+    {
+        // 本家の仕様：引数が2つ以上あるとエラーになる
+        ft_putendl_fd("minishell: cd: too many arguments", STDERR_FILENO);
+        return (NULL);
+    }
+    // 引数が1つの場合 (例: `cd /tmp`) は、その引数をパスにする
+    return (cmd->args[1]);
+}
+
+/*
+** ==========================================
+** 環境変数の更新
+** ==========================================
+** PWD と OLDPWD を新しいパスで上書きするヘルパー関数
+*/
+static int update_pwd_vars(t_shell *shell, char *old_pwd)
+{
+    char *new_pwd;
+
+    // 1. 移動が成功したので、新しい現在地を取得する
+    new_pwd = getcwd(NULL, 0);
+
+    // 2. リストの OLDPWD を、先ほど確保しておいた old_pwd で上書き
+    if (old_pwd)
+    {
+        if (update_env_value(&(shell->env), "OLDPWD", old_pwd) != 0)
+        {
+            perror("minishell: malloc failed");
+            free(old_pwd);
+            free(new_pwd);
+            return (1);
+        }
+    }
+
+    // 3. リストの PWD を、いま取得した new_pwd で上書き
+    if (new_pwd)
+    {
+        if (update_env_value(&(shell->env), "PWD", new_pwd) != 0)
+        {
+            perror("minishell: malloc failed");
+            free(old_pwd);
+            free(new_pwd);
+            return (1);
+        }
+    }
+
+    // 4. getcwd で自動 malloc された文字列を解放する
+    // （リストの中には ft_strdup でコピーされたものが入っているので大元は消してOK）
+    free(old_pwd);
+    free(new_pwd);
+    return (0);
+}
+
+/*
+** ==========================================
+** 実際に移動する (chdir) ＆ 全体の統括
+** ==========================================
+*/
+int ft_cd(t_cmd *cmd, t_shell *shell)
+{
+    char *path;
+    char *old_pwd;
+
+    // 1. どこへ移動するか取得（NULLならエラーなので即終了）
+    path = get_cd_path(cmd, shell);
+    if (path == NULL)
+        return (1);
+
+    // 2. 準備編：移動する「前」の現在地を確保しておく
+    old_pwd = getcwd(NULL, 0);
+    if(!old_pwd){
+        //TODO ここにエラー処理
+        // ft_putendl_fd(old_pwd, STDOUT_FILENO);
+        free(old_pwd);
+    }
+
+    // 3. chdir・・・自プロセスのカレントディレクトリを引数のpathに変更する
+    // 成功すると 0、失敗すると -1 を返す
+    if (chdir(path) != 0)
+    {
+        // 失敗した場合（例: ディレクトリがない、権限がない）
+        perror("minishell: cd");
+        free(old_pwd); // 失敗した時は old_pwd を忘れずに free して終わる
+        return (1);
+    }
+
+    // 4. 移動に成功したら、環境変数の更新処理へ丸投げ
+    return (update_pwd_vars(shell, old_pwd));
+}

--- a/submission/srcs/builtins/builtin_echo.c
+++ b/submission/srcs/builtins/builtin_echo.c
@@ -1,1 +1,83 @@
-/*homura担当*/
+#include "minishell.h"
+#include "libft.h"
+
+// 「コマンドの引数（args）を正しく解析する」
+// `-n` オプション　改行を消す
+
+/*
+echo 実装のポイント：-n オプションの罠
+echo は単に引数を表示するだけに見えるが、本家のBashには「改行を抑制する -n オプション」に関する細かいルールがある。
+
+基本: echo hello → hello\n（改行あり）
+オプション: echo -n hello → hello（改行なし）
+罠1（連続）: echo -nnnnn hello → これも -n とみなされ、改行なし。
+罠2（複数）: echo -n -n -n hello → これもすべてオプションとみなされ、改行なし。
+罠3（引数扱い）: echo -nhello → これはオプションではなく、ただの文字列として出力。
+*/
+
+
+/*-----テストケース-----
+minishell> echo hello world
+→ hello world（改行あり）が出るか？
+
+minishell> echo -n hello
+→ hello の後にすぐプロンプトが戻ってくるか？
+
+minishell> echo -n -n -nnnn hello
+→ ちゃんとオプションとして無視され、hello だけが出るか？
+
+minishell> echo -nnna hello
+→ オプションではなく文字列として扱われる
+
+minishell> echo "-n" hello
+→ Expander（展開処理） が正しく動いていれば、クォートが外れて -n として判定される
+*/
+
+// オプション "-n" かどうかを判定するヘルパー関数
+// "-nnnn" のような形式も許容するBashの仕様に対応
+static bool is_n_option(char *arg)
+{
+    int i;
+
+    if (!arg || arg[0] != '-' || arg[1] != 'n')
+        return (false);
+    i = 2;
+    while (arg[i])
+    {
+        if (arg[i] != 'n')
+            return (false);
+        i++;
+    }
+    return (true);
+}
+
+int ft_echo(t_cmd *cmd)
+{
+    int     i;
+    bool    n_flag;
+
+    n_flag = false;
+    i = 1; // args[0] は "echo" なので飛ばす
+
+    // 1. オプション "-n" が続く限り読み飛ばし、フラグを立てる
+    while (cmd->args[i] && is_n_option(cmd->args[i]))
+    {
+        n_flag = true;
+        i++;
+    }
+
+    // 2. 残りの引数をスペース区切りで出力
+    while (cmd->args[i])
+    {
+        ft_putstr_fd(cmd->args[i], STDOUT_FILENO);
+        if (cmd->args[i + 1]) // 次の引数がある場合のみスペースを出す
+            ft_putchar_fd(' ', STDOUT_FILENO);
+        i++;
+    }
+
+    // 3. -n フラグが立っていなければ、最後に改行を出力
+    if (!n_flag)
+        ft_putchar_fd('\n', STDOUT_FILENO);
+
+    return (0);
+}

--- a/submission/srcs/builtins/builtin_utils.c
+++ b/submission/srcs/builtins/builtin_utils.c
@@ -29,9 +29,10 @@ int exec_builtin(t_cmd *cmd, t_shell *shell)
         return (ft_env(shell));
     if (ft_strncmp(name, "echo", 5) == 0)
         return (ft_echo(cmd));
+    if (ft_strncmp(name, "cd", 3) == 0)
+        return (ft_cd(cmd, shell));
     // 他のコマンドも実装したらここに追加していきます
     /*
-    if (ft_strncmp(name, "cd", 3) == 0) return (ft_cd(cmd, shell));
     if (ft_strncmp(name, "export", 7) == 0) return (ft_export(cmd, shell));
     if (ft_strncmp(name, "unset", 6) == 0) return (ft_unset(cmd, shell));
     if (ft_strncmp(name, "exit", 5) == 0) return (ft_exit(cmd, shell));

--- a/submission/srcs/builtins/builtin_utils.c
+++ b/submission/srcs/builtins/builtin_utils.c
@@ -27,9 +27,10 @@ int exec_builtin(t_cmd *cmd, t_shell *shell)
         return (ft_pwd());
     if (ft_strncmp(name, "env", 4) == 0)
         return (ft_env(shell));
+    if (ft_strncmp(name, "echo", 5) == 0)
+        return (ft_echo(cmd));
     // 他のコマンドも実装したらここに追加していきます
     /*
-    if (ft_strncmp(name, "echo", 5) == 0) return (ft_echo(cmd));
     if (ft_strncmp(name, "cd", 3) == 0) return (ft_cd(cmd, shell));
     if (ft_strncmp(name, "export", 7) == 0) return (ft_export(cmd, shell));
     if (ft_strncmp(name, "unset", 6) == 0) return (ft_unset(cmd, shell));

--- a/submission/srcs/env/env_update.c
+++ b/submission/srcs/env/env_update.c
@@ -1,0 +1,89 @@
+#include "minishell.h"
+#include "libft.h"
+
+/*------------------------------------------------------------------
+** t_env リストから key を探し、見つかったらその value を new_value で上書きする関数
+------------------------------------------------------------------*/
+
+/* ** 1. リストの末尾に追加する汎用関数（後で export でも使い回せます！）
+*/
+void env_add_back(t_env **head, t_env *new_node)
+{
+    t_env *current;
+
+    if (!head || !new_node)
+        return ;
+    if (*head == NULL) // c. リストの末尾に繋ぐ
+        *head = new_node;  // これが最初のノードになる
+    else
+    {
+        current = *head;
+        while (current->next != NULL) // 最後尾を探す
+            current = current->next;
+        current->next = new_node; // 末尾に繋ぐ
+    }
+}
+
+/* ** 2. 新規ノードを作成して追加する関数
+*/
+static int add_new_env_node(t_env **env_head, char *key, char *value)
+{
+    t_env *new_node;
+
+    // a. 新しいノードの作成
+    new_node = malloc(sizeof(t_env));
+    if (!new_node)
+        return (1);
+
+    // b. key と value を複製してセット
+    new_node->key = ft_strdup(key);
+    new_node->value = NULL;
+    if (value)
+        new_node->value = ft_strdup(value);
+    new_node->next = NULL;
+    // どちらかの malloc が失敗した場合のエラー処理
+    if (!new_node->key || (value && !new_node->value))
+    {
+        free(new_node->key);
+        free(new_node->value); // free(NULL)は安全なのでif不要
+        free(new_node);
+        return (1);
+    }
+    env_add_back(env_head, new_node);
+    return (0);
+}
+
+/* ** 3. メインの更新関数
+*/
+int update_env_value(t_env **env_head, char *key, char *new_value)
+{
+    t_env *current;
+
+    if (!env_head || !key)
+        return (1);
+    current = *env_head;
+    while (current)
+    {
+        if (ft_strncmp(current->key, key, ft_strlen(key) + 1) == 0)
+        {
+            // 1. 古い値を free してメモリリークを防ぐ
+            free(current->value); // 古い値を解放 (NULLでも安全)
+            current->value = NULL;
+
+            // 2. 新しい値を strdup で複製して代入する
+            if (new_value)
+            {
+                current->value = ft_strdup(new_value);
+                if (!current->value)
+                    return (1); // malloc失敗
+            }
+            else
+                current->value = NULL;
+
+            return (0); // 上書き成功
+        }
+        current = current->next;
+    }
+    // ループを抜けた＝見つからなかったので、追加関数に丸投げ！
+    return (add_new_env_node(env_head, key, new_value));
+}


### PR DESCRIPTION
ビルトインcd追加しました。
ここまでで、Aさん担当は終わりです。

cd作成時、環境変数の書き換えが必要になったので、
/srcs/env/env_update.cを追加しました。

ビルトインexportを作成する時に
リストの末尾に追加する汎用関数を作成したのですが、
export でも使い回しできるっぽいです。(使わなくてもOKです！)