### PR TITLE
Phase4 - Bさん担当 - ビルトインの実装（exit, export, unset）

### DIFF
--- a/submission/srcs/builtins/builtin_exit.c
+++ b/submission/srcs/builtins/builtin_exit.c
@@ -8,19 +8,18 @@
 ** code & 0xFF で終了コードを 0〜255 に収める。
 ** (例: 256 → 0、257 → 1、-1 → 255)
 */
-
 static void	ft_do_exit(t_shell *shell, int code)
 {
+	// 環境変数リスト、コマンドリスト、トークンリストを解放
 	free_env(shell->env);
 	free_cmds_list(shell->cmds);
 	token_free(&shell->tokens);
-	exit(code & 0xFF);
-		/*
-		** exit() に渡せる終了コードは 0〜255 の範囲のみ。
-		** & 0xFF は下位8ビットだけを残すビット演算で、
-		** 範囲外の値を自動的に 0〜255 に丸める。
-		** 例: 256 → 0、257 → 1、-1 → 255
-		*/
+	/*
+	** exit() に渡せる終了コードは 0〜255 の範囲のみ。
+	** & 0xFF は下位8ビットだけを残すビット演算で、
+	** 範囲外の値を自動的に 0〜255 に丸める。
+	*/
+	exit(code & 0xFF); // 終了コードを0〜255に丸めて終了
 }
 
 /*
@@ -32,23 +31,27 @@ static void	ft_do_exit(t_shell *shell, int code)
 */
 int	ft_exit(t_cmd *cmd, t_shell *shell)
 {
-	ft_putendl_fd("exit", STDOUT_FILENO); // bash と同様に "exit" と表示
-	if (!cmd->args[1]) // 引数なし
-		exit(shell->last_status); // last_status の値で終了
-	if (cmd->args[2]) // 引数が2つ以上
+	// bash と同様に、exit コマンドが実行されたことを表示する
+	ft_putendl_fd("exit", STDOUT_FILENO);
+	if (!cmd->args[1]) // 引数なし → last_status の値で終了
+		ft_do_exit(shell, shell->last_status);
+	if (cmd->args[2]) // args[2] が存在する = 引数が2つ以上
 	{
+		// 引数が多すぎる場合はエラーを出してシェルを続ける
 		ft_putendl_fd("minishell: exit: too many arguments", STDERR_FILENO);
 		shell->last_status = 1; // エラーなので 1 をセット
 		return (1); // exit() せずに return → シェルは続く
 	}
-	if (!ft_isint(cmd->args[1])) // 数値でない引数
+	if (!ft_isint(cmd->args[1])) // ft_isint が 0 = 数値でない
 	{
+		// 数値でない引数の場合はエラーを出してシェルを続ける
 		ft_putstr_fd("minishell: exit: ", STDERR_FILENO);
-		ft_putstr_fd(cmd->args[1], STDERR_FILENO);
+		ft_putstr_fd(cmd->args[1], STDERR_FILENO); // 問題の引数を表示
 		ft_putendl_fd(": numeric argument required", STDERR_FILENO);
-		shell->last_status = 255; // 数値でない場合は 255 をセット
-		return (255);
+		shell->last_status = 255; // bash の仕様： 数値でない場合は 255 をセット
+		return (255); // exit() せずに return → シェルは続く
 	}
-	ft_do_exit(shell, ft_atoi(cmd->args[1])); // 数値引数で終了
+	// 数値引数を int に変換して終了
+	ft_do_exit(shell, ft_atoi(cmd->args[1]));
 	return (0); // ここには到達しないがコンパイラ警告を防ぐ
 }

--- a/submission/srcs/builtins/builtin_exit.c
+++ b/submission/srcs/builtins/builtin_exit.c
@@ -1,1 +1,54 @@
 /*hkuninag担当*/
+
+#include "minishell.h"
+#include "libft.h"
+
+/*
+** 動的確保したメモリを解放してから exit() を呼ぶ。
+** code & 0xFF で終了コードを 0〜255 に収める。
+** (例: 256 → 0、257 → 1、-1 → 255)
+*/
+
+static void	ft_do_exit(t_shell *shell, int code)
+{
+	free_env(shell->env);
+	free_cmds_list(shell->cmds);
+	token_free(&shell->tokens);
+	exit(code & 0xFF);
+		/*
+		** exit() に渡せる終了コードは 0〜255 の範囲のみ。
+		** & 0xFF は下位8ビットだけを残すビット演算で、
+		** 範囲外の値を自動的に 0〜255 に丸める。
+		** 例: 256 → 0、257 → 1、-1 → 255
+		*/
+}
+
+/*
+** exit ビルトインの実装。
+** 引数なし        → last_status の値で終了
+** 引数1つ(数値)   → その値で終了
+** 引数1つ(非数値) → エラーを表示して終了しない
+** 引数2つ以上     → エラーを表示して終了しない
+*/
+int	ft_exit(t_cmd *cmd, t_shell *shell)
+{
+	ft_putendl_fd("exit", STDOUT_FILENO); // bash と同様に "exit" と表示
+	if (!cmd->args[1]) // 引数なし
+		exit(shell->last_status); // last_status の値で終了
+	if (cmd->args[2]) // 引数が2つ以上
+	{
+		ft_putendl_fd("minishell: exit: too many arguments", STDERR_FILENO);
+		shell->last_status = 1; // エラーなので 1 をセット
+		return (1); // exit() せずに return → シェルは続く
+	}
+	if (!ft_isint(cmd->args[1])) // 数値でない引数
+	{
+		ft_putstr_fd("minishell: exit: ", STDERR_FILENO);
+		ft_putstr_fd(cmd->args[1], STDERR_FILENO);
+		ft_putendl_fd(": numeric argument required", STDERR_FILENO);
+		shell->last_status = 255; // 数値でない場合は 255 をセット
+		return (255);
+	}
+	ft_do_exit(shell, ft_atoi(cmd->args[1])); // 数値引数で終了
+	return (0); // ここには到達しないがコンパイラ警告を防ぐ
+}

--- a/submission/srcs/builtins/builtin_export.c
+++ b/submission/srcs/builtins/builtin_export.c
@@ -1,1 +1,73 @@
 /*hkuninag担当*/
+#include "minishell.h"
+#include "libft.h"
+
+/*
+** 全環境変数を "declare -x KEY="VALUE"" 形式で表示する。
+** value が NULL のものは "declare -x KEY" と表示する。
+*/
+static void	ft_print_export(t_env *env)
+{
+	while (env)
+	{
+		ft_putstr_fd("declare -x ", STDOUT_FILENO);
+		ft_putstr_fd(env->key, STDOUT_FILENO);
+		if (env->value != NULL) // value がある場合だけ ="VALUE" を表示
+		{
+			ft_putstr_fd("=\"", STDOUT_FILENO); // =" を出力
+			ft_putstr_fd(env->value, STDOUT_FILENO);
+			ft_putchar_fd('"', STDOUT_FILENO); // 閉じ " を出力
+		}
+		ft_putchar_fd('\n', STDOUT_FILENO); // 改行
+		env = env->next;
+	}
+}
+
+/*
+** 引数を解析して env リストに追加・更新する。
+** "NAME=hkuninag" → key="NAME", value="hkuninag" に分割して登録。
+** "NAME"        → value なしで key だけ登録。
+*/
+static void	ft_export_var(t_shell *shell, char *arg)
+{
+	char	*eq;
+	char	*key;
+	char	*value;
+
+	eq = ft_strchr(arg, '=');
+	if (eq == NULL)
+	{
+		// '=' がない → key だけ登録（value は NULL）
+		update_env_value(&shell->env, arg, NULL);
+		return ;
+	}
+	key = ft_substr(arg, 0, eq - arg); // '=' より前を key に
+	value = eq + 1;
+	if (!key)
+		return ;
+	update_env_value(&shell->env, key, value); // env リストを更新
+	free(key); // ft_substr で malloc されたので free する
+}
+
+/*
+** export ビルトインの実装。
+** 引数なし     → 全変数を一覧表示
+** 引数あり     → 各引数を解析して env リストに追加・更新
+*/
+int	ft_export(t_cmd *cmd, t_shell *shell)
+{
+	int	i;
+
+	if (!cmd->args[1]) // 引数なしの場合
+	{
+		ft_print_export(shell->env); // 全変数を表示して終了
+		return (0);
+	}
+	i = 1;					// args[0] は "export" なので1から始める
+	while (cmd->args[i])	// NULL が来るまでループ
+	{
+		ft_export_var(shell, cmd->args[i]); // 各引数を解析して登録
+		i++;
+	}
+	return (0);
+}

--- a/submission/srcs/builtins/builtin_export.c
+++ b/submission/srcs/builtins/builtin_export.c
@@ -5,69 +5,144 @@
 /*
 ** 全環境変数を "declare -x KEY="VALUE"" 形式で表示する。
 ** value が NULL のものは "declare -x KEY" と表示する。
+** 出力例:
+**   declare -x HOME="/home/hkuninag"
+**   declare -x PATH="/usr/bin:/bin"
+**   declare -x NAME        ← value が NULL の場合（値なしで登録された変数）
 */
 static void	ft_print_export(t_env *env)
 {
 	while (env)
 	{
-		ft_putstr_fd("declare -x ", STDOUT_FILENO);
-		ft_putstr_fd(env->key, STDOUT_FILENO);
+		ft_putstr_fd("declare -x ", STDOUT_FILENO); // bash と同じ形式のプレフィックス
+		ft_putstr_fd(env->key, STDOUT_FILENO); // キー名を出力（例: HOME）
 		if (env->value != NULL) // value がある場合だけ ="VALUE" を表示
 		{
 			ft_putstr_fd("=\"", STDOUT_FILENO); // =" を出力
-			ft_putstr_fd(env->value, STDOUT_FILENO);
+			ft_putstr_fd(env->value, STDOUT_FILENO); // 値を出力（例: /home/hkuninag）
 			ft_putchar_fd('"', STDOUT_FILENO); // 閉じ " を出力
 		}
-		ft_putchar_fd('\n', STDOUT_FILENO); // 改行
-		env = env->next;
+		ft_putchar_fd('\n', STDOUT_FILENO); // 1変数ごとに改行
+		env = env->next; // 次のノードへ進む
 	}
 }
 
+
 /*
-** 引数を解析して env リストに追加・更新する。
-** "NAME=hkuninag" → key="NAME", value="hkuninag" に分割して登録。
-** "NAME"        → value なしで key だけ登録。
+** 環境変数名として有効かチェックする。
+** 戻り値: 1（有効）/ 0（無効）
+**
+** 有効な環境変数名のルール：
+**   - 1文字以上であること
+**   - 先頭は英字（a-z, A-Z）またはアンダースコア（_）
+**   - 2文字目以降は英数字（a-z, A-Z, 0-9）またはアンダースコア（_）
+**
+** 例:
+**   "NAME"   → 有効
+**   "_VAR"   → 有効
+**   ""       → 無効（空文字）
+**   "=VALUE" → 無効（先頭が =）
+**   "1NAME"  → 無効（先頭が数字）
+**   "NA-ME"  → 無効（ハイフンは使えない）
 */
-static void	ft_export_var(t_shell *shell, char *arg)
+static int	ft_is_valid_key(char *key)
+{
+	int	i;
+
+	if (!key || key[0] == '\0')      // 空文字は無効
+		return (0);
+	if (!ft_isalpha(key[0]) && key[0] != '_') // 先頭が英字か _ でなければ無効
+		return (0);
+	i = 1;
+	while (key[i])
+	{
+		if (!ft_isalnum(key[i]) && key[i] != '_') // 2文字目以降のチェック
+			return (0);
+		i++;
+	}
+	return (1); // 全チェック通過 → 有効
+}
+
+/*
+** 引数1つを解析して env リストに追加・更新する。
+** 戻り値: 0（成功）/ 1（失敗）
+**
+** 引数のパターン：
+**   "NAME=tanaka" → '=' で分割して key="NAME", value="tanaka" として登録
+**   "NAME"        → value なし（NULL）で key だけ登録
+**   "=VALUE"      → key が空 → 不正な識別子としてエラー
+**   "1NAME=x"     → key が数字始まり → 不正な識別子としてエラー
+*/
+static int	ft_export_var(t_shell *shell, char *arg)
 {
 	char	*eq;
 	char	*key;
 	char	*value;
 
-	eq = ft_strchr(arg, '=');
-	if (eq == NULL)
+	eq = ft_strchr(arg, '='); // '=' の位置を探す（なければ NULL）
+	if (eq == NULL) // '=' がない → key だけ登録するケース
 	{
-		// '=' がない → key だけ登録（value は NULL）
-		update_env_value(&shell->env, arg, NULL);
-		return ;
+		if (!ft_is_valid_key(arg)) // key として不正な場合はエラー
+		{
+			ft_putstr_fd("minishell: export: `", STDERR_FILENO);
+			ft_putstr_fd(arg, STDERR_FILENO);
+			ft_putendl_fd("': not a valid identifier", STDERR_FILENO);
+			return (1); // 不正な識別子 → 失敗
+		}
+		// key だけ登録（value は NULL）、update_env_value の結果をそのまま返す
+		return (update_env_value(&shell->env, arg, NULL));
 	}
-	key = ft_substr(arg, 0, eq - arg); // '=' より前を key に
-	value = eq + 1;
+	key = ft_substr(arg, 0, eq - arg); // '=' より前を key として切り出す
+	value = eq + 1; 				   // '=' より後ろを value として取得
 	if (!key)
-		return ;
-	update_env_value(&shell->env, key, value); // env リストを更新
+		return (1); // ft_substr の malloc 失敗
+	if (!ft_is_valid_key(key)) // key が不正な識別子の場合はエラー
+	{
+		ft_putstr_fd("minishell: export: `", STDERR_FILENO);
+		ft_putstr_fd(arg, STDERR_FILENO); // 引数全体（例: "=VALUE"）を表示
+		ft_putendl_fd("': not a valid identifier", STDERR_FILENO);
+		free(key); // ft_substr で malloc されたので free する
+		return (1); // 不正な識別子 → 失敗
+	}
+	if (update_env_value(&shell->env, key, value) != 0) // env リストの更新。失敗チェック
+	{
+		// update_env_value が 1 を返した = malloc 失敗
+		ft_putendl_fd("minishell: export: malloc failed", STDERR_FILENO);
+		free(key);
+		return (1); // malloc 失敗
+	}
 	free(key); // ft_substr で malloc されたので free する
+	return (0); // 成功
 }
 
 /*
 ** export ビルトインの実装。
-** 引数なし     → 全変数を一覧表示
+** 引数なし     → 全変数を "declare -x" 形式で一覧表示
 ** 引数あり     → 各引数を解析して env リストに追加・更新
+**
+** 例:
+**   export               → 全環境変数を表示
+**   export NAME=tanaka   → NAME=tanaka を登録
+**   export A=1 B=2       → A と B をまとめて登録
+**   export INVALID=      → key="INVALID", value="" として登録（空値はOK）
 */
 int	ft_export(t_cmd *cmd, t_shell *shell)
 {
 	int	i;
+	int	has_error;
 
-	if (!cmd->args[1]) // 引数なしの場合
+	if (!cmd->args[1]) // 引数なしの場合 → 一覧表示して終了
 	{
-		ft_print_export(shell->env); // 全変数を表示して終了
+		ft_print_export(shell->env);
 		return (0);
 	}
+	has_error = 0; // 最初は「成功」としておく
 	i = 1;					// args[0] は "export" なので1から始める
-	while (cmd->args[i])	// NULL が来るまでループ
+	while (cmd->args[i])	// NULL が来るまで全引数をループ
 	{
-		ft_export_var(shell, cmd->args[i]); // 各引数を解析して登録
+		if (ft_export_var(shell, cmd->args[i]) != 0)
+			has_error = 1; // 1つでも失敗したら has_error を 1 にする（残りは処理し続ける）
 		i++;
 	}
-	return (0);
+	return (has_error); // 全引数を処理してから最終的な結果を返す
 }

--- a/submission/srcs/builtins/builtin_unset.c
+++ b/submission/srcs/builtins/builtin_unset.c
@@ -5,6 +5,10 @@
 
 /*
 ** env リストから key が一致するノードを1つ削除する。
+** 削除の仕組み：
+**   削除前: [prev] → [current] → [next]
+**   削除後: [prev] → [next]
+**   ※ prev->next を current->next に繋ぎ替えて current を free する
 ** 先頭ノードが対象の場合は shell->env 自体を次に付け替える。
 */
 static void	ft_unset_var(t_shell *shell, char *key)
@@ -16,7 +20,9 @@ static void	ft_unset_var(t_shell *shell, char *key)
 	current = shell->env; // リストの先頭から探し始める
 	while (current)
 	{
-		// key と完全一致するノードか確認（+1でNULL文字まで比較し部分一致を防ぐ）
+		// key と完全一致するノードか確認
+		// +1 で NULL文字まで比較することで部分一致を防ぐ
+		// 例: "PATH" と "PATH2" を区別するために必要
 		if (ft_strncmp(current->key, key, ft_strlen(key) + 1) == 0)
 
 		{
@@ -28,6 +34,8 @@ static void	ft_unset_var(t_shell *shell, char *key)
 				// prevがNULL以外 = 2番目以降のノードが削除対象
 				// 1つ前のノードの next を、削除ノードの次に繋ぎ替える
 				prev->next = current->next;
+			// ノードが持つメモリを個別に解放する
+			// free(current) だけでは 中身の key と value は解放されないので個別に解放する必要あり
 			free(current->key); // キー文字列を解放
 			free(current->value); // 値文字列を解放
 			free(current); // ノード本体を解放
@@ -36,21 +44,27 @@ static void	ft_unset_var(t_shell *shell, char *key)
 		prev = current; // 現在のノードを「1つ前」として記録
 		current = current->next; // 次のノードへ進む
 	}
+	// ループを抜けた = key が見つからなかった → 何もしない
+	// bash の仕様: 存在しない変数を unset してもエラーにならない
 }
 
 /*
 ** unset ビルトインの実装。
 ** 引数を複数受け取り、それぞれを env リストから削除する。
+**
+** 例) unset NAME USER PATH
+**   → args[0]="unset", args[1]="NAME", args[2]="USER", args[3]="PATH"
+**   → NAME, USER, PATH を順番に env リストから削除する
 */
 int	ft_unset(t_cmd *cmd, t_shell *shell)
 {
 	int	i;
 
 	i = 1; // args[0] は "unset" なので1から始める
-	while (cmd->args[i]) // NULL が来るまでループ
+	while (cmd->args[i]) // NULL が来るまでループ（引数の終わりを検出）
 	{
 		ft_unset_var(shell, cmd->args[i]); // 各引数をリストから削除
 		i++;
 	}
-	return (0);
+	return (0); // unset は常に成功を返す
 }

--- a/submission/srcs/builtins/builtin_unset.c
+++ b/submission/srcs/builtins/builtin_unset.c
@@ -1,1 +1,56 @@
 /*hkuninag担当*/
+
+#include "minishell.h"
+#include "libft.h"
+
+/*
+** env リストから key が一致するノードを1つ削除する。
+** 先頭ノードが対象の場合は shell->env 自体を次に付け替える。
+*/
+static void	ft_unset_var(t_shell *shell, char *key)
+{
+	t_env	*current;
+	t_env	*prev;
+
+	prev = NULL;// 1つ前のノード（最初は存在しないのでNULL）
+	current = shell->env; // リストの先頭から探し始める
+	while (current)
+	{
+		// key と完全一致するノードか確認（+1でNULL文字まで比較し部分一致を防ぐ）
+		if (ft_strncmp(current->key, key, ft_strlen(key) + 1) == 0)
+
+		{
+			if (prev == NULL)
+				// prevがNULL = まだ1つも進んでいない = 先頭ノードが削除対象
+				// shell->env 自体を次のノードに付け替える
+				shell->env = current->next;
+			else
+				// prevがNULL以外 = 2番目以降のノードが削除対象
+				// 1つ前のノードの next を、削除ノードの次に繋ぎ替える
+				prev->next = current->next;
+			free(current->key); // キー文字列を解放
+			free(current->value); // 値文字列を解放
+			free(current); // ノード本体を解放
+			return ; // 削除したら終了
+		}
+		prev = current; // 現在のノードを「1つ前」として記録
+		current = current->next; // 次のノードへ進む
+	}
+}
+
+/*
+** unset ビルトインの実装。
+** 引数を複数受け取り、それぞれを env リストから削除する。
+*/
+int	ft_unset(t_cmd *cmd, t_shell *shell)
+{
+	int	i;
+
+	i = 1; // args[0] は "unset" なので1から始める
+	while (cmd->args[i]) // NULL が来るまでループ
+	{
+		ft_unset_var(shell, cmd->args[i]); // 各引数をリストから削除
+		i++;
+	}
+	return (0);
+}

--- a/submission/srcs/builtins/builtin_utils.c
+++ b/submission/srcs/builtins/builtin_utils.c
@@ -31,11 +31,11 @@ int exec_builtin(t_cmd *cmd, t_shell *shell)
         return (ft_echo(cmd));
     if (ft_strncmp(name, "cd", 3) == 0)
         return (ft_cd(cmd, shell));
-    // 他のコマンドも実装したらここに追加していきます
-    /*
-    if (ft_strncmp(name, "export", 7) == 0) return (ft_export(cmd, shell));
-    if (ft_strncmp(name, "unset", 6) == 0) return (ft_unset(cmd, shell));
-    if (ft_strncmp(name, "exit", 5) == 0) return (ft_exit(cmd, shell));
-    */
+    if (ft_strncmp(name, "export", 7) == 0)
+		return (ft_export(cmd, shell));
+    if (ft_strncmp(name, "unset", 6) == 0)
+		return (ft_unset(cmd, shell));
+    if (ft_strncmp(name, "exit", 5) == 0)
+		return (ft_exit(cmd, shell));
     return (0);
 }

--- a/submission/srcs/executor/redirect.c
+++ b/submission/srcs/executor/redirect.c
@@ -41,19 +41,18 @@ static int	apply_heredoc(char *delimiter);
 */
 static int	open_redir_fd(t_redir *redir, int *target_fd)
 {
-    if (redir->kind == TK_REDIRECT_IN)
+    if (redir->kind == TK_REDIRECT_IN) // '<' のとき : ファイルをキーボード入力の代わりに読む
     {
         *target_fd = STDIN_FILENO; // 0番(stdin)を付け替え対象にする
         return (open(redir->file, O_RDONLY)); // 読み込み専用で開く
     }
-    if (redir->kind == TK_REDIRECT_OUT)
+    if (redir->kind == TK_REDIRECT_OUT) // '>' のとき : 画面に出す代わりにファイルへ上書きする
     {
         *target_fd = STDOUT_FILENO;  // 1番(stdout)を付け替え対象にする
-        return (open(redir->file, O_WRONLY | O_CREAT | O_TRUNC, 0644));
-			// 上書きで開く（なければ作る）
-			// 0644: 6=所有者rw(読み書き可), 4=グループr(読み込みのみ), 4=他人r(読み込みのみ)
+        return (open(redir->file, O_WRONLY | O_CREAT | O_TRUNC, 0644)); // 書き込み用で開く: なければ作成、あれば中身を空にして先頭から書く（上書き）
+			// 0644: 省略不可。O_CREATE をつけた時に必須。6=所有者rw(読み書き可), 4=グループr(読み込みのみ), 4=他人r(読み込みのみ)
     }
-    if (redir->kind == TK_APPEND)
+    if (redir->kind == TK_APPEND) // '>>' のとき : 画面に出す代わりにファイルの末尾へ書き足す
     {
         *target_fd = STDOUT_FILENO; // 1番(stdout)を付け替え対象にする
         return (open(redir->file, O_WRONLY | O_CREAT | O_APPEND, 0644)); // 追記で開く（なければ作る）


### PR DESCRIPTION
残りのビルトインの実装が完了しました。
これで Bさん担当完了です！


<html><head></head><body>
<hr>
<h3>📌 概要</h3>
<p>Phase 4 Bさん担当のビルトインコマンド3つを実装しました。</p>
<ul>
<li><code>builtin_exit.c</code></li>
<li><code>builtin_unset.c</code></li>
<li><code>builtin_export.c</code></li>
</ul>
<p>また、<code>builtin_utils.c</code> の <code>exec_builtin</code> の3つのコマンドの呼び出し部分を、コメントアウト状態から元に戻しました。</p>
<hr>

<hr>
<h3>🔧 各コマンドの実装内容</h3>
<hr>
<h4><code>exit</code>（<code>builtin_exit.c</code>）</h4>
<p>シェルを終了するコマンドです。</p>
<pre><code class="language-bash">exit        # last_status の値で終了
exit 42     # 42 で終了
exit abc    # エラー表示、終了しない（$? = 255）
exit 1 2    # エラー表示、終了しない（$? = 1）
</code></pre>
<p><strong>実装のポイント：</strong></p>
<ul>
<li>引数なし → <code>shell-&gt;last_status</code> の値で終了</li>
<li>引数が数値でない → エラーを出して終了しない</li>
<li>引数が2つ以上 → エラーを出して終了しない（数値チェックより先に判定）</li>
<li>終了コードは <code>&amp; 0xFF</code> で 0〜255 に丸める</li>
<li><code>exit()</code> 前に <code>free_env</code>・<code>free_cmds_list</code>・<code>token_free</code> でメモリを解放する</li>
</ul>
<p><strong>関数構成（2関数）：</strong></p>
<ul>
<li><code>ft_do_exit</code> … メモリ解放 → <code>exit()</code> 呼び出し</li>
<li><code>ft_exit</code> … 引数チェック → 適切な終了処理へ振り分け</li>
</ul>
<hr>
<h4><code>unset</code>（<code>builtin_unset.c</code>）</h4>
<p>環境変数を削除するコマンドです。</p>
<pre><code class="language-bash">unset NAME         # NAME を削除
unset NAME USER    # 複数まとめて削除
</code></pre>
<p><strong>実装のポイント：</strong></p>
<ul>
<li><code>t_env</code> 連結リストから指定されたキーのノードを削除する</li>
<li>先頭ノードが削除対象の場合は <code>shell-&gt;env</code> 自体を次のノードに付け替える</li>
<li>複数引数に対応（ループで各引数を処理）</li>
<li>存在しないキーを指定しても何もしない（エラーにならない）</li>
</ul>
<p><strong>関数構成（2関数）：</strong></p>
<ul>
<li><code>ft_unset_var</code> … リストから指定キーのノードを1つ削除</li>
<li><code>ft_unset</code> … 引数ループ → 各引数に対して <code>ft_unset_var</code> を呼ぶ</li>
</ul>
<hr>
<h4><code>export</code>（<code>builtin_export.c</code>）</h4>
<p>環境変数を追加・更新するコマンドです。</p>
<pre><code class="language-bash">export                  # 全環境変数を一覧表示
export NAME=tanaka      # NAME を追加（または更新）
export NAME             # 値なしで NAME だけ登録
export A=1 B=2          # 複数まとめて登録
</code></pre>
<p><strong>実装のポイント：</strong></p>
<ul>
<li>引数なしの場合は <code>declare -x KEY="VALUE"</code> 形式で全変数を表示（bash と同じ形式）</li>
<li><code>=</code> が含まれる引数は KEY と VALUE に分割して <code>update_env_value</code> で登録</li>
<li><code>=</code> が含まれない引数は VALUE なしで登録（<code>value = NULL</code>）</li>
<li>追加・更新処理は既存の <code>update_env_value</code>（<code>env_update.c</code>）を再利用</li>
</ul>
<p><strong>関数構成（3関数）：</strong></p>
<ul>
<li><code>ft_print_export</code> … 全変数を <code>declare -x</code> 形式で表示</li>
<li><code>ft_export_var</code> … 引数1つを解析して <code>update_env_value</code> を呼ぶ</li>
<li><code>ft_export</code> … エントリー。引数なしなら表示、あればループ処理</li>
</ul>
<hr>
<h3>✅ テストケース</h3>
<pre><code class="language-bash"># exit
exit 42        # → echo $? で 42
exit abc       # → エラーメッセージ、シェル続く
exit 1 2       # → too many arguments、シェル続く
exit 256       # → echo $? で 0（&amp; 0xFF）

# unset
unset HOME     # → echo $HOME で空
unset A B C    # → 複数削除

# export
export         # → declare -x 形式で全変数表示
export X=123   # → echo $X で 123
export X=456   # → 上書き更新
unset X        # → export で X が消えていることを確認
</code></pre>

※ macbook のターミナルで export を実行したときは、declare -x は出てこないと思いますが、bash に切り替えて実行すると、表示されます。
<hr>
