### PR TITLE
tokenizer でクォートが閉じられていないときにエラー表示をするよう機能追加

### DIFF
--- a/submission/includes/minishell.h
+++ b/submission/includes/minishell.h
@@ -93,6 +93,7 @@ void		token_free(t_token **head);
 bool		is_space(char c);
 bool		is_metachar(char c);
 void		consume_space(char **line);
+int			has_unclosed_quote(char *line);
 
 // token_operator.c
 void		append_operator(t_token **head, char **line);

--- a/submission/srcs/tokenizer/token_operator.c
+++ b/submission/srcs/tokenizer/token_operator.c
@@ -83,6 +83,11 @@ void append_word(t_token **head, char **line)
     start = *line; // 1. 開始位置をメモ
     quote = 0;     // 0は「クォートに入っていない」状態
 
+
+    // クォート内のスペースやメタ文字を単語の区切りとして
+    // 扱わないために、クォートの開閉状態を追跡する。
+    // 例: "hello world" → スペースを無視して1トークンにする
+
     //TODO: 閉じクォートがないときの処理がないのでは？？
     while (**line)
     {
@@ -110,7 +115,7 @@ void append_word(t_token **head, char **line)
     // ※ ft_substr(文字列, 開始インデックス, 長さ)
     //文字列の一部を切り出して新しい文字列を作成する関数（substring = 部分文字列）。
     // ここではポインタの引き算で長さを出しています
-    //!ft_substrはmalloc使用。どこでfreeする？ 
+    //!ft_substrはmalloc使用。どこでfreeする？
     word_str = ft_substr(start, 0, *line - start);
     if(!word_str)
         return;

--- a/submission/srcs/tokenizer/tokenizer.c
+++ b/submission/srcs/tokenizer/tokenizer.c
@@ -1,13 +1,29 @@
 #include "minishell.h"
+#include "libft.h"
 
+
+/*
+** 入力文字列 line をトークンに分割し、連結リストとして返す。
+** 以下の順で処理する：
+**   1. クォートの閉じ忘れチェック（エラーなら NULL を返す）
+**   2. スペースを読み飛ばす
+**   3. メタ文字（| < >）はオペレータトークンとして追加
+**   4. それ以外は単語トークンとして追加
+**   5. 終端に TK_EOF トークンを追加して返す
+*/
 t_token *tokenize(char *line)
 {
 	t_token *head; // リストの先頭
-	head = NULL;
 
+	head = NULL;
 	if(line == NULL)
 		return NULL;
-
+	if (has_unclosed_quote(line)) // 閉じ忘れクォートがあればエラー
+	{
+		ft_putendl_fd("minishell: syntax error: unclosed quote",
+			STDERR_FILENO);
+		return (NULL); // NULL を返すと minishell_loop 側でエラー扱いになる
+	}
 	while (*line)
 	{
 		// 1. スペース読み飛ばし

--- a/submission/srcs/tokenizer/tokenizer_utils.c
+++ b/submission/srcs/tokenizer/tokenizer_utils.c
@@ -16,3 +16,33 @@ void consume_space(char **line) {
 	while (**line && is_space(**line))
 		(*line)++;
 }
+
+/*
+** クォート（' または "）が正しく閉じられているか確認する。
+** 閉じられていない場合は 1 を返す。
+** 例:
+**   echo 'hello'  → 0（正常）
+**   echo 'hello   → 1（エラー: シングルクォートが閉じていない）
+**   echo "hello  → 1（エラー: ダブルクォートが閉じていない）
+*/
+int	has_unclosed_quote(char *line)
+{
+	char	quote;
+
+	quote = 0; // 0 = 現在クォートの外にいる
+	while (*line)
+	{
+		if (quote) // クォートの中にいる
+		{
+			if (*line == quote) // 開いたクォートと同じ文字が来たら
+				quote = 0;      // クォートを閉じる（外に出る）
+		}
+		else // クォートの外にいる
+		{
+			if (*line == '\'' || *line == '"')
+				quote = *line; // クォートを開く（中に入る）
+		}
+		line++;
+	}
+	return (quote != 0); // まだ quote が残っている = 閉じ忘れ
+}


### PR DESCRIPTION
今までは、クォート （" や '）が閉じられていなくても、そのまま処理してしまっていたんですが、今回エラー表示をするように対応させました！
echo 'hello などを入力すると、token化せず、エラーを表示するように変更しました。
