### PR TITLE
branchの削除方法を追加。ヘッダにプロトタイプ追加 + 整頓。tokenizerのファイル分割/関数分割/エラー処理

### DIFF
--- a/github/branch.md
+++ b/github/branch.md
@@ -1,29 +1,63 @@
 # mainの内容を自分のブランチに取り組む方法
 
 ### ①mainブランチに移動
+
 git checkout main
 
 ### ②リモートのmainを取得
+
 git pull
 (このコマンドで機能するように、事前に git branch --set-upstream-to=origin/main main コマンドで設定しておく)
 
 ### ③homuraブランチに移動
+
 git checkout homura(/hkuninag)
 
 ### ④mainの内容をhomuraに取り込む
+
 git merge main
 
 ### ⑤リモートのhomuraに反映
+
 git push origin homura(/hkuninag)
 
-
---------------------------------------
+---
 
 # 自分のブランチの確認方法
 
 `git branch`
 
-
 # ブランチの移動方法
 
 `git branch <移動したいブランチ>`
+
+# 🧹 PRマージ後の完璧なお掃除手順
+
+## **1. mainブランチに戻って、最新状態にする**
+
+```bash
+git checkout main
+git pull origin main
+```
+
+## **2. GitHub（リモート）上のブランチを削除する**
+
+```bash
+git push origin --delete 削除したいブランチ名
+```
+
+_(※GitHubのWeb画面のボタンで削除した場合は、このコマンドは不要)_
+
+## **3. GitHubで消えた情報を、手元のGitにも反映（同期）させる**
+
+```bash
+git fetch --prune
+```
+
+リモートのブランチの状況を反映
+
+## **4. 手元のPC（ローカル）に残っているブランチも削除する**
+
+```bash
+git branch -d 削除したいブランチ名
+```

--- a/submission/Makefile
+++ b/submission/Makefile
@@ -21,6 +21,7 @@ SRCS        = main.c \
               tokenizer/tokenizer.c \
               tokenizer/tokenizer_utils.c \
               tokenizer/token_operator.c \
+              tokenizer/token_word.c \
               tokenizer/token.c \
               parser/parser.c \
               parser/parser_utils.c \

--- a/submission/includes/minishell.h
+++ b/submission/includes/minishell.h
@@ -15,10 +15,12 @@
 # define PINK "\033[0;35m"
 # define RESET "\033[0m"
 
-// グローバル変数宣言
+// global
 extern int	g_signal;
 
-/* --- Enum & Structs --- */
+/***********************************
+Enum & Structs
+***********************************/
 
 // トークンの種類(識別子)を表す列挙型enum
 typedef enum e_token_kind
@@ -72,15 +74,25 @@ typedef struct s_shell {
 } t_shell;
 
 
-/* --- Prototypes --- */
+/************************************
+Prototypes
+************************************/
 
-// main.c
+/*----------------------------------------
+main (main.c)
+----------------------------------------*/
 void		minishell_loop(t_shell *shell);
-void		setup_signals(void);
 
-/*
-    tokenizer
-*/
+/*----------------------------------------
+signal (signal.c)
+----------------------------------------*/
+void		setup_signals(void);
+void		set_signal_for_parent_wait(void);
+void		set_signal_for_child(void);
+
+/*----------------------------------------
+tokenizer
+----------------------------------------*/
 // tokenizer.c
 t_token		*tokenize(char *line);
 
@@ -99,9 +111,9 @@ int			has_unclosed_quote(char *line);
 void		append_operator(t_token **head, char **line);
 void		append_word(t_token **head, char **line);
 
-/*
+/*----------------------------------------
 parser
-*/
+----------------------------------------*/
 // parser.c
 t_cmd		*parse(t_token *tokens);
 
@@ -119,9 +131,9 @@ char	*ft_append_char(char *result, char *str, int *i);
 char	*ft_append_expanded(char *result, char *part);
 char    *ft_get_dollar_value(char *str, int *i, t_shell *shell);
 
-/*
+/*----------------------------------------
 env
-*/
+----------------------------------------*/
 // env_init.c
 t_env   *init_env(char **envp);
 
@@ -131,13 +143,9 @@ char    *get_env_value(t_env *env, char *key);
 char    **env_to_envp(t_env *env);
 int update_env_value(t_env **env, char *key, char *new_value);
 
-// debug.c
-void debug_print_tokens(t_token *tokens); //! Debug提出前に削除
-void debug_print_cmds(t_cmd *cmd); //! Debug提出前に削除
-
-/*
+/*----------------------------------------
 excecter
-*/
+----------------------------------------*/
 // executor.c
 void    ft_execute(t_shell *shell);
 
@@ -159,9 +167,9 @@ int     open_all_pipes(int (*pipes)[2], int pipe_count);
 void    close_all_pipes(int (*pipes)[2], int pipe_count);
 void    wait_all_cmds(pid_t *pids, int cmd_count, t_shell *shell);
 
-/*
- builtins
-*/
+/*----------------------------------------
+builtins
+----------------------------------------*/
 
 //builtin_echo.c
 int     ft_echo(t_cmd *cmd);
@@ -189,5 +197,11 @@ int     is_builtin(char *cmd);
 int     exec_builtin(t_cmd *cmd, t_shell *shell);
 
 
+/*----------------------------------------
+others
+----------------------------------------*/
+// debug.c
+void debug_print_tokens(t_token *tokens); //! Debug提出前に削除
+void debug_print_cmds(t_cmd *cmd); //! Debug提出前に削除
 
 #endif /* MINISHELL_H */

--- a/submission/includes/minishell.h
+++ b/submission/includes/minishell.h
@@ -108,8 +108,8 @@ void		consume_space(char **line);
 int			has_unclosed_quote(char *line);
 
 // token_operator.c
-void		append_operator(t_token **head, char **line);
-void		append_word(t_token **head, char **line);
+int		append_operator(t_token **head, char **line);
+int		append_word(t_token **head, char **line);
 
 /*----------------------------------------
 parser

--- a/submission/srcs/tokenizer/token_operator.c
+++ b/submission/srcs/tokenizer/token_operator.c
@@ -1,130 +1,81 @@
 #include "minishell.h"
 #include "libft.h"
 
-// 演算子トークンを作成し、リストに追加し、入力読み込み位置を進める
-void append_operator(t_token **head, char **line)
+// malloc失敗時は 0 を返し、成功時は 1 を返す
+// 新しいノードを作ってリストに繋ぐ
+static int	add_operator_token(t_token **head, char *operator_str, t_token_kind kind)
 {
-    t_token_kind kind;
-    char *operator_str;//!わかりにくいのでoperator_strがいいかも
-    operator_str = NULL;
+	t_token	*new_token;
 
-    // 1. 種類と文字列の決定
-    if (**line == '|')
-    {
-        kind = TK_PIPE;
-        operator_str = ft_strdup("|");
-        if (!operator_str)
-            return;
-        (*line)++; // 1文字進める
-    }
-    else if (**line == '>')
-    {
-        // 次の文字を「先読み」
-        if ((*line)[1] == '>')//「現在の場所から見て何番目か？」を表している
-        {
-            kind = TK_APPEND;
-            operator_str = ft_strdup(">>");
-            if (!operator_str)
-                return;
-            (*line) += 2; // 2文字進める
-        }
-        else
-        {
-            kind = TK_REDIRECT_OUT;
-            operator_str = ft_strdup(">");
-            if (!operator_str)
-                return;
-            (*line)++; // 1文字進める
-        }
-    }
-    else if (**line == '<')
-    {
-        // 次の文字を「先読み」
-        if ((*line)[1] == '<')
-        {
-            kind = TK_HEREDOC;
-            operator_str = ft_strdup("<<");
-            if (!operator_str)
-                return;
-            (*line) += 2; // 2文字進める
-        }
-        else
-        {
-            kind = TK_REDIRECT_IN;
-            operator_str = ft_strdup("<");
-            if (!operator_str)
-                return;
-            (*line)++; // 1文字進める
-        }
-    }
-    else
-    {
-        // 不明な演算子（エラー処理を追加することも可能）
-        return;
-    }
-
-    // 2. 新しいノードを作ってリストに繋ぐ
-    t_token *new_token = token_new(operator_str, kind);
-    if (!new_token)
-    {
-        free(operator_str); // token_new失敗時にoperator_strがリークしないように
-        return;
-    }
-    token_add_back(head, new_token);
+	if (!operator_str)
+		return (0);
+	new_token = token_new(operator_str, kind);
+	if (!new_token)
+	{
+		free(operator_str);
+		return (0);
+	}
+	token_add_back(head, new_token);
+	return (1);
 }
 
-// 単語の終了位置までポインタを進め、トークンを作成する
-void append_word(t_token **head, char **line)
+// 演算子トークンを作成し、リストに追加し、入力読み込み位置を進める
+static int append_pipe(t_token **head, char **line)
 {
-    char *start;
-    char *word_str;
-    char quote;
+	char *operator_str;
+	(*line)++; // 1文字進める
+	operator_str = ft_strdup("|");
+    if(operator_str == NULL)
+        return (0);
+    return (add_operator_token(head, operator_str, TK_PIPE));
+}
 
-    start = *line; // 1. 開始位置をメモ
-    quote = 0;     // 0は「クォートに入っていない」状態
+static int	append_redirect_in(t_token **head, char **line)
+{
+	char	*operator_str;
 
+	if ((*line)[1] == '<') // 次の文字を「先読み」 //「現在の場所から見て何番目か？」を表している
+	{
+		(*line) += 2; // 2文字進める
+		operator_str = ft_strdup("<<");
+        if(operator_str == NULL)
+            return (0);
+		return (add_operator_token(head, operator_str, TK_HEREDOC));
+	}
+	(*line)++;
+	operator_str = ft_strdup("<");
+    if(operator_str == NULL)
+        return (0);
+	return (add_operator_token(head, operator_str, TK_REDIRECT_IN));
+}
 
-    // クォート内のスペースやメタ文字を単語の区切りとして
-    // 扱わないために、クォートの開閉状態を追跡する。
-    // 例: "hello world" → スペースを無視して1トークンにする
+static int	append_redirect_out(t_token **head, char **line)
+{
+	char	*operator_str;
 
-    //TODO: 閉じクォートがないときの処理がないのでは？？
-    while (**line)
-    {
-        // A. クォート中の処理
-        if (quote)
-        {
-            if (**line == quote) // 閉じクォートが見つかったら
-                quote = 0;       // 通常モードに戻る
-        }
-        // B. 通常モードの処理
-        else
-        {
-            // スペースかメタ文字が来たら、単語の終わり！
-            if (is_space(**line) || is_metachar(**line))
-                break;
+	if ((*line)[1] == '>') // 次の文字を「先読み」 //「現在の場所から見て何番目か？」を表している
+	{
+		(*line) += 2; // 2文字進める
+		operator_str = ft_strdup(">>");
+        if(operator_str == NULL)
+            return (0);
+		return (add_operator_token(head, operator_str, TK_APPEND));
+	}
+	(*line)++;
+	operator_str = ft_strdup(">");
+    if(operator_str == NULL)
+        return (0);
+	return (add_operator_token(head, operator_str, TK_REDIRECT_OUT));
+}
 
-            // クォートの始まりを見つけたら、クォートモードへ
-            if (**line == '\'' || **line == '\"')
-                quote = **line; // ' か " を記録する
-        }
-        (*line)++; // 次の文字へ
-    }
+int append_operator(t_token **head, char **line)
+{
+    if (**line == '|')
+		return (append_pipe(head, line));
+    else if (**line == '>')
+        return (append_redirect_out(head, line));
+    else if (**line == '<')
+        return (append_redirect_in(head, line));
 
-    // 2. 切り出し (start から 現在の *line まで)
-    // ※ ft_substr(文字列, 開始インデックス, 長さ)
-    //文字列の一部を切り出して新しい文字列を作成する関数（substring = 部分文字列）。
-    // ここではポインタの引き算で長さを出しています
-    //!ft_substrはmalloc使用。どこでfreeする？
-    word_str = ft_substr(start, 0, *line - start);
-    if(!word_str)
-        return;
-
-    // 3. リストに追加
-    t_token *new_token = token_new(word_str, TK_WORD);
-    if (!new_token) {
-        free(word_str);
-        return;
-    }
-    token_add_back(head, new_token);
+    return (1);
 }

--- a/submission/srcs/tokenizer/token_word.c
+++ b/submission/srcs/tokenizer/token_word.c
@@ -1,0 +1,54 @@
+#include "minishell.h"
+#include "libft.h"
+
+// ポインタを進める処理
+// クォート内のスペースやメタ文字を単語の区切りとして扱わないために、クォートの開閉状態を追跡する。
+// 例: "hello world" → スペースを無視して1トークンにする
+static void	advance_word_ptr(char **line)
+{
+	char	quote;
+
+	quote = 0; // 0は「クォートに入っていない」状態
+	while (**line)
+	{
+		if (quote && **line == quote) // クォートの中の処理 && 閉じクォートが見つかったら
+			quote = 0;
+		else if (!quote)
+		{
+			if (is_space(**line) || is_metachar(**line))
+				break ;
+			if (**line == '\'' || **line == '\"')
+				quote = **line;
+		}
+		(*line)++;
+	}
+}
+
+// 単語の終了位置までポインタを進め、トークンを作成する
+int append_word(t_token **head, char **line)
+{
+    char *start;
+    char *word_str;
+    t_token *new_token;
+
+    start = *line; // 1. 開始位置をメモ
+    advance_word_ptr(line);
+
+    // 2. 切り出し (start から 現在の *line まで)
+    // ※ ft_substr(文字列, 開始インデックス, 長さ)
+    //文字列の一部を切り出して新しい文字列を作成する関数（substring = 部分文字列）。
+    // ここではポインタの引き算で長さを出しています
+    //!ft_substrはmalloc使用。どこでfreeする？
+    word_str = ft_substr(start, 0, *line - start);
+    if(!word_str)
+        return (0);
+
+    // 3. リストに追加
+    new_token = token_new(word_str, TK_WORD);
+    if (!new_token) {
+        free(word_str);
+        return (0);
+    }
+    token_add_back(head, new_token);
+    return (1);
+}

--- a/submission/srcs/tokenizer/tokenizer.c
+++ b/submission/srcs/tokenizer/tokenizer.c
@@ -1,6 +1,41 @@
 #include "minishell.h"
 #include "libft.h"
 
+// 1. ループで文字を読み進め、トークンリストを構築する
+static int	process_tokens(t_token **head, char **line)
+{
+	while (**line)
+	{
+		if (is_space(**line))
+			consume_space(line);
+		else if (is_metachar(**line))
+		{
+			if (!append_operator(head, line))
+				return (0);
+		}
+		else
+		{
+			if (!append_word(head, line))
+				return (0);
+		}
+	}
+	return (1);
+}
+
+// 2. 最後に EOF トークンを追加する。malloc失敗時は全破棄する
+static t_token	*append_eof(t_token **head)
+{
+	t_token	*eof_token;
+
+	eof_token = token_new(NULL, TK_EOF);
+	if (!eof_token)
+	{
+		token_free(head);
+		return (NULL);
+	}
+	token_add_back(head, eof_token);
+	return (*head);
+}
 
 /*
 ** 入力文字列 line をトークンに分割し、連結リストとして返す。
@@ -24,22 +59,11 @@ t_token *tokenize(char *line)
 			STDERR_FILENO);
 		return (NULL); // NULL を返すと minishell_loop 側でエラー扱いになる
 	}
-	while (*line)
+	if (!process_tokens(&head, &line))
 	{
-		// 1. スペース読み飛ばし
-		// TODO is_spaceはlibftのft_isspaceの方がいいか？
-		if (is_space(*line))
-			consume_space(&line);
-
-		// 2. メタ文字（| < >）の処理
-		else if (is_metachar(*line))
-			append_operator(&head, &line);
-
-		// 3. 一般単語（文字, クォート含む）の処理
-		else
-			append_word(&head, &line);
+		token_free(&head);
+		return (NULL);
 	}
 	// 4. 最後にEOFトークンを追加しておくと便利
-	token_add_back(&head, token_new(NULL, TK_EOF));
-	return (head);
+	return (append_eof(&head));
 }


### PR DESCRIPTION
branchの削除方法を追加しました。

ヘッダにsignal関連のプロトタイプ追加するのを忘れていたため、makeできない状態でした。
→追加し、make可能になりました。

ヘッダが見にくかったので見やすく整頓しました。