### PR TITLE
heredoc実行の関数名をわかりやすく変更

### DIFF
--- a/submission_vogsphere/includes/minishell.h
+++ b/submission_vogsphere/includes/minishell.h
@@ -153,7 +153,7 @@ excecter
 void				ft_execute(t_shell *shell);
 char				*search_path(char *cmd, t_env *env);
 int					ft_apply_redirs(t_cmd *cmd);
-int					apply_heredoc(char *delimiter);
+int					read_heredoc_input(char *delimiter);
 int					prepare_heredocs(t_cmd *cmd);
 void				ft_execute_pipeline(t_shell *shell);
 int					count_cmds(t_cmd *cmd);

--- a/submission_vogsphere/srcs/executor/exec_utils.c
+++ b/submission_vogsphere/srcs/executor/exec_utils.c
@@ -50,7 +50,7 @@ void	do_execve(char *path, t_cmd *cmd, t_shell *shell)
 /*
 ** Sets signals to wait mode, calls waitpid, then restores signals.
 ** Returns 0 on success, -1 on waitpid error. Called by exec_external
-** and apply_heredoc.
+** and read_heredoc_input.
 */
 int	wait_for_child(pid_t pid, int *status)
 {

--- a/submission_vogsphere/srcs/executor/redirect.c
+++ b/submission_vogsphere/srcs/executor/redirect.c
@@ -20,7 +20,7 @@
 static int	apply_heredoc_redir(t_redir *redir)
 {
 	if (redir->fd == -1)
-		redir->fd = apply_heredoc(redir->file);
+		redir->fd = read_heredoc_input(redir->file);
 	if (redir->fd == -1 || dup2(redir->fd, STDIN_FILENO) == -1)
 		return (-1);
 	close(redir->fd);

--- a/submission_vogsphere/srcs/executor/redirect_heredoc.c
+++ b/submission_vogsphere/srcs/executor/redirect_heredoc.c
@@ -67,7 +67,7 @@ static int	apply_heredoc_wait(pid_t pid, int *pipefd)
 	return (pipefd[0]);
 }
 
-int	apply_heredoc(char *delimiter)
+int	read_heredoc_input(char *delimiter)
 {
 	int		pipefd[2];
 	pid_t	pid;
@@ -103,7 +103,7 @@ int	prepare_heredocs(t_cmd *cmd)
 		{
 			if (redir->kind == TK_HEREDOC)
 			{
-				redir->fd = apply_heredoc(redir->file);
+				redir->fd = read_heredoc_input(redir->file);
 				if (redir->fd == -1)
 					return (-1);
 			}


### PR DESCRIPTION
heredocを実行する関数の名前がappy_heredocとなっていましたが、他にもapply_heredoc_redirs という関数もあるため、紛らわしい状態でした。

read_heredoc_inputという名前に変えることで、理解しやすくしました。